### PR TITLE
修正卡牌关联活动

### DIFF
--- a/refer/cards/CardDetail.tsx
+++ b/refer/cards/CardDetail.tsx
@@ -559,7 +559,7 @@ const CardDetail: React.FC<unknown> = observer(() => {
           );
       }
       const _eventCards = eventCardsCache.filter(
-        (elem) => elem.cardId === Number(cardId)
+        (elem) => elem.cardId === Number(cardId) && elem.isDisplayCardStory
       );
       if (_eventCards && _eventCards.length)
         setEvent(


### PR DESCRIPTION
eventCards.json中有isDisplayCardStory属性，为false的不算该活动的剧情卡牌。 

wl2的卡目前都被错误关联到了wl终章180期活动，wl2卡的id出现了两次，在wl2活动中isDisplayCardStory为true，在180期中则为false，虽然我看到后面有选取了_eventCards[0]，按理说不该被关联到180吧。

bfes卡的isDisplayCardStory也为false，感觉也可以不显示关联活动，就像cfes卡一样，虽然cfes卡是因为在eventCards.json中直接没有条目。