### PR TITLE
fix(web): 修复深色模式下的文字颜色

### DIFF
--- a/web/src/app/prediction/client.tsx
+++ b/web/src/app/prediction/client.tsx
@@ -425,7 +425,7 @@ export default function PredictionClient() {
                                                 </div>
 
                                                 {banner.status === "ongoing" && (
-                                                    <div className="absolute bottom-0 right-2 text-4xl sm:text-5xl font-black text-black select-none z-10 tracking-tighter">
+                                                    <div className="absolute bottom-0 right-2 text-4xl sm:text-5xl font-black text-black dark:text-white select-none z-10 tracking-tighter">
                                                         {Math.floor(banner.progressPercent)}<span className="text-2xl ml-1">%</span>
                                                     </div>
                                                 )}

--- a/web/src/components/home/CurrentEventTab.tsx
+++ b/web/src/components/home/CurrentEventTab.tsx
@@ -174,7 +174,7 @@ export default function CurrentEventTab() {
                     {/* Big Percentage (Bottom Right) - Fully opaque black */}
                     {status === "ongoing" && (
                         <div
-                            className="absolute bottom-0 right-2 text-4xl sm:text-5xl font-black text-black select-none z-10 tracking-tighter"
+                            className="absolute bottom-0 right-2 text-4xl sm:text-5xl font-black text-black dark:text-white select-none z-10 tracking-tighter"
                         >
                             {Math.floor(progressPercent)}<span className="text-2xl ml-1">%</span>
                         </div>


### PR DESCRIPTION
### Before

<img width="832" height="300" alt="image" src="https://github.com/user-attachments/assets/a6d34bcc-f612-41f2-bc91-e7a47e780d0b" />

### After

<img width="829" height="302" alt="image" src="https://github.com/user-attachments/assets/48109885-03f9-4694-a517-314f323ef75b" />
