### PR TITLE
改进深色模式下猜曲绘和猜角色的结果样式

### DIFF
--- a/web/src/app/guess-jacket/client.tsx
+++ b/web/src/app/guess-jacket/client.tsx
@@ -674,7 +674,7 @@ function GuessJacketContent() {
                                         <Link
                                             href={`/music/${result.music.id}`}
                                             key={result.round}
-                                            className={`block p-4 rounded-xl border transition-transform hover:-translate-y-1 hover:shadow-md ${result.isCorrect ? "bg-green-50/90 border-green-200" : "bg-red-50/90 border-red-200"}`}
+                                            className={`block p-4 rounded-xl border transition-transform hover:-translate-y-1 hover:shadow-md ${result.isCorrect ? "bg-green-50/90 dark:bg-black/50 border-green-200" : "bg-red-50/90 dark:bg-black/50 border-red-200"}`}
                                         >
                                             <div className="flex gap-4">
                                                 <div className="w-16 h-16 relative rounded-lg overflow-hidden shadow-sm ring-1 ring-black/10 shrink-0">

--- a/web/src/app/guess-who/client.tsx
+++ b/web/src/app/guess-who/client.tsx
@@ -656,7 +656,7 @@ function GuessWhoContent() {
                             <div className="p-8 bg-slate-50/30">
                                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-left">
                                     {currentResults.map((res, idx) => (
-                                        <Link href={`/cards/${res.card.id}`} key={idx} className={`relative block p-4 rounded-xl border flex gap-4 overflow-hidden transition-transform hover:-translate-y-1 hover:shadow-md ${res.isCorrect ? "bg-green-50/90 border-green-200" : "bg-red-50/90 border-red-200"}`}>
+                                        <Link href={`/cards/${res.card.id}`} key={idx} className={`relative block p-4 rounded-xl border flex gap-4 overflow-hidden transition-transform hover:-translate-y-1 hover:shadow-md ${res.isCorrect ? "bg-green-50/90 dark:bg-black/50 border-green-200" : "bg-red-50/90 dark:bg-black/50 border-red-200"}`}>
                                             <div className="absolute inset-0 z-0 opacity-20 pointer-events-none">
                                                 <CanvasImage image={activeImagesRef.current[res.round]} objectFit="cover" />
                                             </div>


### PR DESCRIPTION
当前样式下结果卡片文字难以看清，做此修改以改进深色模式下的阅读体验

<img width="1087" height="376" alt="图片" src="https://github.com/user-attachments/assets/762f7db8-0ade-4151-976e-e8c62def989d" />

<img width="1126" height="191" alt="图片" src="https://github.com/user-attachments/assets/b8e39df9-bce2-4a52-acf3-bb29ac99137b" />

