### PR TITLE
fix(ui): 修复`inline-block`和`aspectRatio: '1 / 1'`同时存在导致的空白

### DIFF
--- a/web/src/components/cards/SekaiCardThumbnail.tsx
+++ b/web/src/components/cards/SekaiCardThumbnail.tsx
@@ -120,7 +120,7 @@ export default function SekaiCardThumbnail({
 
     return (
         <div
-            className={`relative inline-block select-none ${className}`}
+            className={`relative ${className ? "" : "inline-block"} select-none ${className}`}
             style={className ? { aspectRatio: '1 / 1' } : { width, height: width }}
         >
             <svg


### PR DESCRIPTION
Before(right)
After(left)

<img width="207" height="180" alt="image" src="https://github.com/user-attachments/assets/2a51228a-761f-46de-98a8-ec8b8432d4f4" />
