### PR TITLE
修复烤森预览器问题

### DIFF
--- a/web/src/lib/mysekai-preview/runtime.ts
+++ b/web/src/lib/mysekai-preview/runtime.ts
@@ -2097,6 +2097,7 @@ export class MysekaiScenePreviewRuntime {
         const targets: StaticMergeTarget[] = [];
         this.contentGroup.traverse((node) => {
             if (!isMesh(node) || !node.parent || !this.canMergeStaticMesh(node)) return;
+            if (!node.visible) return;
             targets.push({ mesh: node });
         });
         return targets;

--- a/web/src/lib/mysekai-preview/runtime.ts
+++ b/web/src/lib/mysekai-preview/runtime.ts
@@ -54,6 +54,7 @@ const FREE_LOOK_BASE_MOUSE_SENSITIVITY = 0.0022;
 const FREE_LOOK_BASE_TOUCH_SENSITIVITY = 0.005;
 const FREE_LOOK_MOVE_SPEED = 18;
 const FREE_LOOK_FAST_MULTIPLIER = 1.75;
+const FLOOR_STACKING_BBOX_XZ_OVERLAY_RATIO_THRESHOLD = 0.4;
 
 type MysekaiViewMode = "free" | "fixed";
 
@@ -1755,13 +1756,13 @@ export class MysekaiScenePreviewRuntime {
                         ? below.customPartType === "base" && record.customPartType === "ornament"
                         : below.topY - eps < record.bottomY && below.customPartType === null;
                     if (!isValid) continue;
-                    if (calcBBoxXZAreaOverlayRatio(record.bbox, below.bbox) < 0.8) continue;
+                    if (calcBBoxXZAreaOverlayRatio(record.bbox, below.bbox) < FLOOR_STACKING_BBOX_XZ_OVERLAY_RATIO_THRESHOLD) continue;
                     if (supportTop === null || below.topY > supportTop) supportTop = below.topY;
                 }
                 break;
             }
             if (supportTop !== null && (customOnly || supportTop <= record.bottomY)) {
-                const dy = supportTop - record.bottomY;
+                const dy = supportTop - record.bottomY + eps;
                 record.object.position.y += dy;
                 record.bbox = captureWorldBBox(record.object);
                 record.bottomY = record.bbox.min.y;


### PR DESCRIPTION
1. 降低判断物体叠放时bbox重叠比例的阈值，使得在较小桌子上放置物体导致部分浮空的情况也能正确叠放
2. 物体叠放操作对高度进行矫正后，上方物体高度额外加上eps，避免其模型底部和下方物体产生深度冲突
3. 在进行optimizeStaticContent操作之前visible设为false的网格，进行optimizeStaticContent时直接跳过，避免某些不该显示的网格错误显示