### PR TITLE
fix: 修复本地化链接错误回退到简中路由

### DIFF
--- a/web/src/components/LocalizedLink.tsx
+++ b/web/src/components/LocalizedLink.tsx
@@ -1,22 +1,22 @@
 "use client";
 
 import Link, { type LinkProps } from "next/link";
-import { usePathname } from "next/navigation";
 import type { AnchorHTMLAttributes } from "react";
 
-import { getRouteLocaleFromPathname, localizePath } from "@/lib/localized-path";
-import { DEFAULT_ROUTE_LOCALE } from "@/lib/locale-routing";
+import { useI18n } from "@/contexts/I18nContext";
+import { localizePath } from "@/lib/localized-path";
+import { uiLocaleToRouteLocale } from "@/lib/locale-routing";
 
 type LocalizedLinkProps = LinkProps
     & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>
     & { children?: React.ReactNode };
 
 export default function LocalizedLink({ href, ...props }: LocalizedLinkProps) {
-    const pathname = usePathname();
-    const locale = getRouteLocaleFromPathname(pathname) ?? DEFAULT_ROUTE_LOCALE;
+    const { locale } = useI18n();
+    const routeLocale = uiLocaleToRouteLocale(locale);
     const localizedHref = typeof href === "string"
-        ? localizePath(href, locale)
-        : { ...href, pathname: href.pathname ? localizePath(String(href.pathname), locale) : href.pathname };
+        ? localizePath(href, routeLocale)
+        : { ...href, pathname: href.pathname ? localizePath(String(href.pathname), routeLocale) : href.pathname };
 
     return <Link href={localizedHref} {...props} />;
 }


### PR DESCRIPTION
## 问题

locale proxy 会把 `/en-us/` 这类公开路径重写成内部的 `/`。原来的 `LocalizedLink` 通过 `usePathname()` 判断语言，拿到重写后的路径后会回退到默认的 `zh-cn`。

普通左键导航会被 Next.js client router 修正，所以表面上可能正常；但 SSR 输出的 `href` 已经是 `/zh-cn/...`。复制链接、Ctrl+Click/新标签页和 prefetch 因此都会指向错误语言。

## 修复

`RootLayout` 已经从 proxy header 解析公开路由语言，并注入 `I18nProvider`。这里改为通过 `useI18n()` 读取当前 UI locale，再用 `uiLocaleToRouteLocale()` 转为路由语言，不再从内部 pathname 重新推断。

## 复现与验证

在 Windows 上使用有界面的 Google Chrome 150，对当前 `main`（`718ed41`）和本分支分别运行 standalone build：

- 5 种路由语言，每种 6 轮；每轮使用新的 browser context
- 检查 Sidebar 的全部 47 个链接
- 对 `/materials/` 分别执行 Ctrl+Click 和普通左键导航

基线：

- zh-TW、ja-JP、en-US、ko-KR 共 24/24 轮，47 个 Sidebar `href` 全部变成 `/zh-cn/...`
- 24/24 次 Ctrl+Click 打开 `/zh-cn/materials/`
- 普通左键仍保持当前语言，因为 client router 会修正路径

修复后：

- 30/30 轮没有错误语言链接
- Ctrl+Click 和普通左键导航均保持当前语言
- 没有 console error 或未捕获的 page error
- standalone SSR 中，每种语言检查到 89 个本地化链接，错误语言链接为 0

## 检查

- `npm run lint`
- `npm run lint:i18n --workspace web`
- `npm run lint:i18n-usage --workspace web`
- `npm run build:next --workspace web`
- `git diff --check`