### PR TITLE
refactor: 直接暴露路由语言并补 SSR 链接回归测试

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "eslint",
     "lint:i18n": "node scripts/check-i18n-keys.mjs && node scripts/scan-hardcoded-ui-text.mjs && node scripts/check-seo-routes.mjs",
-    "lint:i18n-usage": "node scripts/check-i18n-usage.mjs"
+    "lint:i18n-usage": "node scripts/check-i18n-usage.mjs",
+    "test:ssr-localized-links": "npm run build:next && node scripts/check-localized-link-ssr.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.95.3",

--- a/web/scripts/check-localized-link-ssr.mjs
+++ b/web/scripts/check-localized-link-ssr.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync } from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROUTE_LOCALES = ["zh-cn", "zh-tw", "ja-jp", "en-us", "ko-kr"];
+const LOCALIZED_HREF_PATTERN = new RegExp(`^/(?:${ROUTE_LOCALES.join("|")})(?:/|$)`, "i");
+const START_TIMEOUT_MS = 30_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const webDirectory = path.resolve(scriptDirectory, "..");
+const serverCandidates = [
+    path.join(webDirectory, ".next", "standalone", "web", "server.js"),
+    path.join(webDirectory, ".next", "standalone", "server.js"),
+];
+const serverPath = serverCandidates.find(existsSync);
+
+assert(serverPath, "Standalone server not found. Run `npm run build:next` first.");
+
+function reservePort() {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            assert(address && typeof address === "object");
+            const { port } = address;
+            server.close((error) => error ? reject(error) : resolve(port));
+        });
+    });
+}
+
+function extractLocalizedHrefs(html) {
+    const hrefs = [];
+    const anchorPattern = /<a\b[^>]*\bhref="([^"]+)"/gi;
+    for (const match of html.matchAll(anchorPattern)) {
+        if (LOCALIZED_HREF_PATTERN.test(match[1])) hrefs.push(match[1]);
+    }
+    return hrefs;
+}
+
+async function fetchHtml(url) {
+    const response = await fetch(url, {
+        headers: { accept: "text/html" },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    assert.equal(response.status, 200, `${url} returned HTTP ${response.status}`);
+    assert.match(response.headers.get("content-type") ?? "", /^text\/html\b/i);
+    return response.text();
+}
+
+async function waitForServer(baseUrl, child) {
+    const deadline = Date.now() + START_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        assert.equal(child.exitCode, null, "Standalone server exited before becoming ready.");
+        try {
+            await fetchHtml(`${baseUrl}/zh-cn/`);
+            return;
+        } catch {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+    }
+    throw new Error(`Standalone server did not become ready within ${START_TIMEOUT_MS}ms.`);
+}
+
+async function stopServer(child) {
+    if (child.exitCode !== null) return;
+    child.kill();
+    await Promise.race([
+        once(child, "exit"),
+        new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
+}
+
+const port = await reservePort();
+const baseUrl = `http://127.0.0.1:${port}`;
+let serverOutput = "";
+const child = spawn(process.execPath, [serverPath], {
+    cwd: path.dirname(serverPath),
+    env: {
+        ...process.env,
+        HOSTNAME: "127.0.0.1",
+        PORT: String(port),
+        NODE_ENV: "production",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+});
+
+child.stdout.on("data", (chunk) => { serverOutput += chunk; });
+child.stderr.on("data", (chunk) => { serverOutput += chunk; });
+
+try {
+    await waitForServer(baseUrl, child);
+
+    for (const routeLocale of ROUTE_LOCALES) {
+        const html = await fetchHtml(`${baseUrl}/${routeLocale}/`);
+        const hrefs = extractLocalizedHrefs(html);
+        const expectedPrefix = `/${routeLocale}/`;
+        const wrongLocaleHrefs = hrefs.filter((href) => !href.toLowerCase().startsWith(expectedPrefix));
+        const paths = hrefs.map((href) => new URL(href, baseUrl).pathname.toLowerCase());
+
+        assert(hrefs.length > 0, `No localized SSR links found for ${routeLocale}.`);
+        assert.deepEqual(
+            wrongLocaleHrefs,
+            [],
+            `${routeLocale} SSR contains links for another route locale: ${wrongLocaleHrefs.slice(0, 5).join(", ")}`,
+        );
+        assert(
+            paths.includes(`${expectedPrefix}materials/`),
+            `${routeLocale} SSR is missing ${expectedPrefix}materials/`,
+        );
+
+        console.log(`${routeLocale}: ${hrefs.length} localized SSR links preserve the route locale`);
+    }
+} catch (error) {
+    if (serverOutput.trim()) console.error(serverOutput.trim());
+    throw error;
+} finally {
+    await stopServer(child);
+}

--- a/web/src/components/LocalizedLink.tsx
+++ b/web/src/components/LocalizedLink.tsx
@@ -5,15 +5,13 @@ import type { AnchorHTMLAttributes } from "react";
 
 import { useI18n } from "@/contexts/I18nContext";
 import { localizePath } from "@/lib/localized-path";
-import { uiLocaleToRouteLocale } from "@/lib/locale-routing";
 
 type LocalizedLinkProps = LinkProps
     & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps>
     & { children?: React.ReactNode };
 
 export default function LocalizedLink({ href, ...props }: LocalizedLinkProps) {
-    const { locale } = useI18n();
-    const routeLocale = uiLocaleToRouteLocale(locale);
+    const { routeLocale } = useI18n();
     const localizedHref = typeof href === "string"
         ? localizePath(href, routeLocale)
         : { ...href, pathname: href.pathname ? localizePath(String(href.pathname), routeLocale) : href.pathname };

--- a/web/src/contexts/I18nContext.tsx
+++ b/web/src/contexts/I18nContext.tsx
@@ -17,6 +17,7 @@ import { getRouteLocaleFromPathname, localizePath } from "@/lib/localized-path";
 
 interface I18nContextType {
     locale: UiLocale;
+    routeLocale: RouteLocale;
     setLocale: React.Dispatch<React.SetStateAction<UiLocale>>;
     t: (key: string, values?: MessageInterpolationValues) => string;
     formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string;
@@ -65,6 +66,10 @@ export function I18nProvider({ children, initialLocale = DEFAULT_UI_LOCALE, rout
     const explicitLocale = routeLocale ? routeLocaleToUiLocale(routeLocale) : undefined;
     const [locale, setLocaleState] = useState<UiLocale>(explicitLocale ?? initialLocale);
     const [hydrated, setHydrated] = useState(false);
+    const resolvedRouteLocale = useMemo(
+        () => routeLocale ?? uiLocaleToRouteLocale(locale),
+        [locale, routeLocale],
+    );
 
     useEffect(() => {
         const resolved = explicitLocale ?? readStoredLocale(initialLocale);
@@ -132,7 +137,15 @@ export function I18nProvider({ children, initialLocale = DEFAULT_UI_LOCALE, rout
     const messages = useMemo(() => messagesByLocale[locale] ?? fallbackMessages, [locale]);
 
     return (
-        <I18nContext.Provider value={{ locale, setLocale, t, formatNumber, formatDate, messages }}>
+        <I18nContext.Provider value={{
+            locale,
+            routeLocale: resolvedRouteLocale,
+            setLocale,
+            t,
+            formatNumber,
+            formatDate,
+            messages,
+        }}>
             {children}
         </I18nContext.Provider>
     );


### PR DESCRIPTION
## 改动

- I18nContext 直接暴露当前 routeLocale
- LocalizedLink 直接使用 routeLocale，不再从 UI locale 反向转换
- 增加 standalone SSR 回归脚本，覆盖 5 种路由语言

## 原因

这是 #40 review 中非阻塞建议的后续。路由语言由 proxy header 注入，直接放进 Context 后，LocalizedLink 的数据来源和语义更一致。

回归脚本会构建并启动 standalone，读取 5 种语言首页的 SSR HTML，检查所有本地化链接和 Materials 链接均保留当前语言。

## 验证

- npm run lint --workspace web
- npm run lint:i18n --workspace web
- npm run lint:i18n-usage --workspace web
- npm run test:ssr-localized-links --workspace web
- 有界面 Chrome：en-US 下 Ctrl+Click 和普通左键均进入 /en-us/materials/，console error 为 0