### PR TITLE
fix: 避免扭蛋列表分页参数触发整数溢出

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -131,13 +131,15 @@ func (h *Handler) handleGachaList(w http.ResponseWriter, r *http.Request) {
 
 	// Paginate
 	total := len(filtered)
-	start := (page - 1) * limit
-	if start > total {
-		start = total
+	start := total
+	pageOffset := page - 1
+	// Check the quotient before multiplying so untrusted page/limit values cannot overflow int.
+	if pageOffset <= total/limit {
+		start = pageOffset * limit
 	}
-	end := start + limit
-	if end > total {
-		end = total
+	end := total
+	if limit < total-start {
+		end = start + limit
 	}
 	paged := filtered[start:end]
 

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"snowy_viewer/internal/masterdata"
+	"snowy_viewer/internal/models"
+)
+
+func TestGachaListPaginationHandlesLargeIntegers(t *testing.T) {
+	maxInt := int(^uint(0) >> 1)
+	tests := []struct {
+		name       string
+		query      string
+		wantGachas int
+	}{
+		{
+			name:       "large page",
+			query:      "page=" + strconv.Itoa(maxInt) + "&limit=2",
+			wantGachas: 0,
+		},
+		{
+			name:       "large limit after first page",
+			query:      "page=2&limit=" + strconv.Itoa(maxInt),
+			wantGachas: 0,
+		},
+		{
+			name:       "large limit on first page",
+			query:      "page=1&limit=" + strconv.Itoa(maxInt),
+			wantGachas: 3,
+		},
+		{
+			name:       "ordinary final page",
+			query:      "page=2&limit=2",
+			wantGachas: 1,
+		},
+	}
+
+	store := masterdata.NewStore("")
+	store.GachaList = []models.Gacha{{ID: 1}, {ID: 2}, {ID: 3}}
+	mux := http.NewServeMux()
+	New(store).RegisterRoutes(mux)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/api/gachas?"+tt.query, nil)
+			response := httptest.NewRecorder()
+
+			mux.ServeHTTP(response, request)
+
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+			}
+
+			var body models.GachaListResponse
+			if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if len(body.Gachas) != tt.wantGachas {
+				t.Fatalf("gachas = %d, want %d", len(body.Gachas), tt.wantGachas)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

`/api/gachas` 直接用请求里的 `page` 和 `limit` 计算切片范围。两者接近 `int` 上限时，乘法或加法会溢出成负数，随后在 `filtered[start:end]` 触发 panic。

本地可以稳定复现：`page=9223372036854775807&limit=2` 会得到负数切片边界；`page=2&limit=9223372036854775807` 也有同类问题。

## 修改

- 在乘法前用商判断页偏移是否仍落在数据范围内
- 用剩余元素数判断是否需要执行 `start + limit`，避免加法溢出
- 从公开路由补了四组回归测试，覆盖超大 page、超大 limit 和正常分页

没有给 `limit` 另设上限，也没有改变无效参数的默认值或超出末页时返回空列表的现有行为。

## 验证

- `go test ./internal/handlers -count=1`
- `go test ./internal/... -count=1`
- `go vet ./internal/...`
- `git diff --check`

补充：仓库根目录现有的 `Dockerfile.go` 会被 Go 工具当成源码解析，因此 `go test ./...` 会在根包扫描阶段报 `illegal character U+0023`；这和本次修改无关。