### PR TITLE
fix: 避免后端 Dockerfile 被 Go 工具链误解析

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -34,4 +34,3 @@ ENV FRONTEND_PROXY_URL=""
 
 # 运行服务
 CMD ["./server"]
-

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ AGPL-3.0
 
 ## Docker 部署 (Go 后端独立部署)
 
-当您在 Pages (如 Cloudflare Pages) 部署了前端静态文件后，可以使用全新的 `Dockerfile.go` 将 Go 后端作为独立服务构建和部署。
+当您在 Pages (如 Cloudflare Pages) 部署了前端静态文件后，可以使用 `Dockerfile.backend` 将 Go 后端作为独立服务构建和部署。
 
 ### 1. 构建 Docker 镜像
 ```bash
-docker build -t pjsk-go-backend -f Dockerfile.go .
+docker build -t pjsk-go-backend -f Dockerfile.backend .
 ```
 
 ### 2. 启动容器


### PR DESCRIPTION
## 问题

仓库根目录的 `Dockerfile.go` 以 `.go` 结尾，因此 Go 工具链会把它当作 Go 源码解析。Dockerfile 第一行以 `#` 开头，导致常用的全仓命令在进入包测试前就失败：

```text
Dockerfile.go:1:1: illegal character U+0023 '#'
```

受影响的命令包括 `go list ./...`、`go test ./...` 和 `go vet ./...`，也会干扰依赖这些命令的编辑器和 CI 检查。

## 修改

- 将后端镜像文件从 `Dockerfile.go` 重命名为 `Dockerfile.backend`
- 同步 README 中的文件名与构建命令

Dockerfile 内容和镜像构建方式没有变化，仍然通过 `docker build -f` 显式指定文件。

## 验证

- `go list ./...`
- `go test ./... -count=1`
- `go vet ./...`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" main.go`
- `npx --yes dockerfilelint Dockerfile.backend`
- `git diff --check`
