### PR TITLE
ci: 增加 pull request 检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,92 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        shell: bash
+        run: |
+          unformatted="$(gofmt -l main.go internal)"
+          if [[ -n "$unformatted" ]]; then
+            echo "The following Go files need formatting:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: go test ./internal/... -count=1
+
+      - name: Run vet
+        run: |
+          go vet main.go
+          go vet ./internal/...
+
+      - name: Build server
+        run: go build -o "$RUNNER_TEMP/moesekai-server" main.go
+
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check translations and SEO
+        run: |
+          bun run --cwd web lint:i18n
+          bun run --cwd web lint:i18n-usage
+
+      - name: Run ESLint
+        run: bun run --cwd web lint
+
+      - name: Build web app
+        run: bun run --cwd web build:next
+
+      - name: Check localized SSR links
+        run: node web/scripts/check-localized-link-ssr.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,25 +68,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
+          cache: npm
+          cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile --registry https://registry.npmjs.org
+        run: npm ci --prefix web
 
       - name: Check translations and SEO
         run: |
-          bun run --cwd web lint:i18n
-          bun run --cwd web lint:i18n-usage
+          npm run lint:i18n --prefix web
+          npm run lint:i18n-usage --prefix web
 
       - name: Run ESLint
-        run: bun run --cwd web lint
+        run: npm run lint --prefix web
 
       - name: Build web app
-        run: bun run --cwd web build:next
+        run: npm run build:next --prefix web
 
       - name: Check localized SSR links
         run: node web/scripts/check-localized-link-ssr.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --registry https://registry.npmjs.org
 
       - name: Check translations and SEO
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sekai-mmw-preview-web"]
+	path = sekai-mmw-preview-web
+	url = https://github.com/watagashi-uni/sekai-mmw-preview-web.git


### PR DESCRIPTION
## 修改

- 新增 PR、`main` push 与手动触发的通用 CI workflow
- Go job 检查 gofmt、单元测试、vet 与服务端构建
- Web job 使用 `web/package-lock.json` 执行 `npm ci`，检查 i18n/SEO、ESLint、Next.js production build 与多语言 SSR 链接
- 补齐 `sekai-mmw-preview-web` 的 `.gitmodules`，避免官方 checkout action 因孤立 gitlink 失败
- 使用只读权限，并取消同一 PR 的旧运行

## 验证

- `actionlint .github/workflows/ci.yml`
- `npm ci --prefix web`
- `go test ./internal/... -count=1`
- `go vet main.go` / `go vet ./internal/...`
- `go build main.go`
- `npm run lint:i18n --prefix web`
- `npm run lint:i18n-usage --prefix web`
- `npm run lint --prefix web`
- `npm run build:next --prefix web`
- `node web/scripts/check-localized-link-ssr.mjs`
- GitHub Actions 的 `CI / Go` 与 `CI / Web` 均已通过

当前仓库没有 branch protection/ruleset；本 PR 先增加检查本身，不修改合并策略。