### PR TITLE
fix(charts): proxy and normalize 2D chart SVGs to restore note rendering (Issue #54)

### DIFF
--- a/web/src/app/chart-svg/[musicId]/[difficulty]/route.ts
+++ b/web/src/app/chart-svg/[musicId]/[difficulty]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const VALID_DIFFICULTIES = new Set(["easy", "normal", "hard", "expert", "master", "append"]);
+const UPSTREAM_CHART_BASE = "https://charts-new.unipjsk.com/moe/svg";
+const ABSOLUTE_NOTES_BASE = "https://charts-new.unipjsk.com/moe/notes_new/";
+
+/**
+ * Normalizes chart SVG to fix upstream asset reference and SVG spec issues:
+ * 1. Rewrites relative note sprite paths (e.g. `../../notes_new/`) to absolute CDN URLs
+ *    at `https://charts-new.unipjsk.com/moe/notes_new/`.
+ * 2. Normalizes negative width/height attributes in clipPath rects which violate the SVG spec.
+ */
+export function normalizeChartSvg(rawSvg: string): string {
+    let svg = rawSvg;
+
+    // Fix relative notes_new paths
+    svg = svg.replaceAll("../../notes_new/", ABSOLUTE_NOTES_BASE);
+    svg = svg.replaceAll("../notes_new/", ABSOLUTE_NOTES_BASE);
+    svg = svg.replaceAll('href="/notes_new/', `href="${ABSOLUTE_NOTES_BASE}`);
+    svg = svg.replaceAll('xlink:href="/notes_new/', `xlink:href="${ABSOLUTE_NOTES_BASE}`);
+
+    // Fix invalid negative width or height values in rect elements (e.g. width="-3.1428571428571423")
+    svg = svg.replace(/\bwidth="-\d+(?:\.\d+)?"/g, 'width="0"');
+    svg = svg.replace(/\bheight="-\d+(?:\.\d+)?"/g, 'height="0"');
+
+    return svg;
+}
+
+export async function GET(
+    request: NextRequest,
+    context: { params: Promise<{ musicId: string; difficulty: string }> }
+) {
+    const { musicId: rawMusicId, difficulty: rawDifficulty } = await context.params;
+
+    // Handle optional trailing .svg in difficulty param (e.g. master.svg -> master)
+    const difficultyClean = rawDifficulty.replace(/\.svg$/i, "").toLowerCase();
+    const musicIdNum = parseInt(rawMusicId, 10);
+
+    if (isNaN(musicIdNum) || musicIdNum <= 0 || !VALID_DIFFICULTIES.has(difficultyClean)) {
+        return new Response("Invalid music ID or difficulty", { status: 400 });
+    }
+
+    const upstreamUrl = `${UPSTREAM_CHART_BASE}/${musicIdNum}/${difficultyClean}.svg`;
+
+    try {
+        const upstreamRes = await fetch(upstreamUrl, {
+            headers: {
+                "User-Agent": "Mozilla/5.0 (Moesekai Chart Proxy)",
+                Accept: "image/svg+xml,*/*",
+            },
+            next: { revalidate: 86400 },
+        });
+
+        if (!upstreamRes.ok) {
+            return new Response(`Upstream error: ${upstreamRes.statusText}`, {
+                status: upstreamRes.status,
+                headers: {
+                    "Cache-Control": "no-store",
+                },
+            });
+        }
+
+        const rawSvg = await upstreamRes.text();
+        const fixedSvg = normalizeChartSvg(rawSvg);
+
+        return new Response(fixedSvg, {
+            status: 200,
+            headers: {
+                "Content-Type": "image/svg+xml; charset=utf-8",
+                "Cache-Control": "public, max-age=86400, s-maxage=604800, stale-while-revalidate=86400",
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+            },
+        });
+    } catch (error) {
+        return new Response(`Failed to fetch chart: ${error instanceof Error ? error.message : "Unknown error"}`, {
+            status: 502,
+            headers: {
+                "Cache-Control": "no-store",
+            },
+        });
+    }
+}

--- a/web/src/lib/assets.ts
+++ b/web/src/lib/assets.ts
@@ -201,7 +201,7 @@ export function getMusicScoreUrl(musicId: number, difficulty: string, source: As
 }
 
 export function getChartSvgUrl(musicId: number, difficulty: string, _source: AssetSourceType = "main-jp"): string {
-    return `https://charts-new.unipjsk.com/moe/svg/${musicId}/${difficulty}.svg`;
+    return `/chart-svg/${musicId}/${difficulty}.svg`;
 }
 
 export function getMusicJacketUrl(assetbundleName: string, source: AssetSourceType = "main-jp"): string {

--- a/web/tests/characterization/ui-music.characterization.test.mjs
+++ b/web/tests/characterization/ui-music.characterization.test.mjs
@@ -254,6 +254,31 @@ test("music SEO remains server-wired for list and detail independently of lyrics
   assert.match(readWeb("src/lib/seo-keywords.ts"), /music: definePage\(\s*"\/music"/);
 });
 
+test("2D chart SVG normalization rewrites relative note asset paths and fixes negative rect dimensions", () => {
+  const routeSource = readWeb("src/app/chart-svg/[musicId]/[difficulty]/route.ts");
+  assert.match(routeSource, /export async function GET/);
+
+  const match = routeSource.match(/export function normalizeChartSvg\((?:[\s\S]*?\n\})/);
+  assert.ok(match, "normalizeChartSvg should be exported");
+  const js = stripTypeScriptTypes(match[0].replace(/^export\s+/, ""), { mode: "transform" });
+  const normalizeChartSvg = new Function(
+    "ABSOLUTE_NOTES_BASE",
+    `${js}\nreturn normalizeChartSvg;`,
+  )("https://charts-new.unipjsk.com/moe/notes_new/");
+
+  const sampleSvg = `<svg xmlns="http://www.w3.org/2000/svg"><defs><symbol id="notes-0"><image href="../../notes_new/custom01/notes_0.png" width="118"/></symbol><clipPath id="test"><rect x="0" y="0" width="-3.142857" height="30"/></clipPath></defs></svg>`;
+  const normalized = normalizeChartSvg(sampleSvg);
+
+  assert.ok(!normalized.includes("../../notes_new/"), "Relative notes_new path should be removed");
+  assert.ok(normalized.includes("https://charts-new.unipjsk.com/moe/notes_new/custom01/notes_0.png"), "Absolute notes CDN URL should be used");
+  assert.ok(!normalized.includes('width="-3.142857"'), "Negative rect width should be removed");
+  assert.ok(normalized.includes('width="0"'), "Negative rect width should become 0");
+
+  const assetsSource = readWeb("src/lib/assets.ts");
+  assert.match(assetsSource, /export function getChartSvgUrl\(musicId:\s*number,\s*difficulty:\s*string/);
+  assert.match(assetsSource, /`\/chart-svg\/\$\{musicId\}\/\$\{difficulty\}\.svg`/);
+});
+
 function runNodeScript(relativePath) {
   return spawnSync(process.execPath, [relativePath], {
     cwd: WEB_ROOT,


### PR DESCRIPTION
Closes #54

## 根因

1. 上游谱面静态服务器更新后，SVG 内音符图片（Tap/Critical/Hold/Flick/Tick 等）改用了相对路径 `../../notes_new/custom01/notes_*.png`。浏览器直接打开 `/moe/svg/{musicId}/{difficulty}.svg` 时，该相对路径向上解析到未配置的 `/notes_new/...`（404），真实资源在 `/moe/notes_new/...`，导致浏览器里所有音符不显示。
2. 上游 SVG 的 clipPath 中存在负数宽度（如 `width="-3.1428..."`），违反 SVG 规范。

## 改动

- 新增 2D 谱面代理与规范化路由 `web/src/app/chart-svg/[musicId]/[difficulty]/route.ts`：
  - 代理上游 SVG，并把 `../../notes_new/`、`../notes_new/`、`/notes_new/` 等重写为绝对 CDN 路径 `https://charts-new.unipjsk.com/moe/notes_new/`。
  - 把 rect/clipPath 中负数 `width`/`height` 规范化为 `0`。
  - musicId/难度校验、上游错误透传、`image/svg+xml` + CORS + 长缓存响应头。
- `getChartSvgUrl` 改指 `/chart-svg/${musicId}/${difficulty}.svg`。
- 补充特征测试覆盖路径重写与负数尺寸清洗契约。

## 验证

- lint:i18n / lint:i18n-usage / lint 通过
- characterization 测试 125/125 通过（本 PR 复跑受影响文件 14/14）
- Next.js standalone build 成功
- Chromium 桌面 + 移动端实测：谱面、音符与难度切换显示正常